### PR TITLE
Add libcurl-gnutls info to curl

### DIFF
--- a/topics/http-client_engines.md
+++ b/topics/http-client_engines.md
@@ -291,6 +291,8 @@ To use the `WinHttp` engine, follow the steps below:
 For desktop platforms, Ktor also provides the `Curl` engine. This engine is supported for the following platforms: `linuxX64`, `macosX64`, `macosArm64`, `mingwX64`. To use the `Curl` engine, follow the steps below:
 
 1. Install the [libcurl library](https://curl.se/libcurl/).
+   > On Linux, you have to install the `gnutls` version of libcurl.
+
    > On Windows, you may want to consider the [MinGW/MSYS2](FAQ.topic#native-curl) `curl` binary. 
 2. Add the `ktor-client-curl` dependency:
 


### PR DESCRIPTION
I just playing around a bit with ktor, linux and the curl client.
After it failed a few times on the CI machine, I realized that I have to install the `libcurl-gnutls` version.
libcurl has different versions available. 
It also have the `openssl` and `nns` version.
While I can confirm that the `openssl` versions doesn't work, I don't know if it will work with the `nns` version.

Whatever, I think it make sense to document this 🙃 